### PR TITLE
Replace fuse_use_version with fuse_version where appropriate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,4 +50,4 @@ before_install:
 
 install:
   - npm/.bin/npm install
-
+  - node -e "require('./build/Release/fusejs')"

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
             "-fpermissive"
           ],
           "xcode_settings": {
-             "OTHER_CFLAGS": [ "-std=c++11", "-stdlib=libc++","-mmacosx-version-min=10.7" ]
+             "OTHER_CPLUSPLUSFLAGS": [ "-std=c++11", "-mmacosx-version-min=10.7" ]
            },
           "defines": [
           '_FILE_OFFSET_BITS=64', 'FUSE_USE_VERSION=30'

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,7 @@
             "-fpermissive"
           ],
           "xcode_settings": {
-             "OTHER_CPLUSPLUSFLAGS": [ "-std=c++11", "-mmacosx-version-min=10.7" ]
+             "OTHER_CPLUSPLUSFLAGS": ["-stdlib=libc++", "-std=c++11", "-mmacosx-version-min=10.7" ]
            },
           "defines": [
           '_FILE_OFFSET_BITS=64', 'FUSE_USE_VERSION=30'

--- a/src/file_info.cc
+++ b/src/file_info.cc
@@ -234,7 +234,7 @@ namespace NodeFuse {
 
     NAN_GETTER(FileInfo::GetNonSeekable){     
 
-#if FUSE_USE_VERSION > 27 && !__APPLE__
+#if FUSE_VERSION > 27 && !__APPLE__
         FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set(fileInfo->fi.nonseekable ? Nan::True() : Nan::False());
 #else
@@ -247,7 +247,7 @@ namespace NodeFuse {
         if (!value->IsBoolean()) {
             FUSEJS_THROW_EXCEPTION("Invalid value type: ", "a Boolean was expected");
         }
-#if FUSE_USE_VERSION > 28 && !__APPLE__
+#if FUSE_VERSION > 28 && !__APPLE__
         FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
         fileInfo->fi.nonseekable = value->IsTrue() ? 1 : 0;
 #endif

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -241,7 +241,7 @@ namespace NodeFuse {
                 case _FUSE_OPS_SETLK_:
                     break;
                 case _FUSE_OPS_MULTI_FORGET_:
-                    #if FUSE_USE_VERSION > 28
+                    #if FUSE_VERSION > 28
                     RemoteMultiForget(value.req, value.size, static_cast<struct fuse_forget_data *>(value.userdata) );
                     #endif
                     break;
@@ -294,7 +294,7 @@ namespace NodeFuse {
         fuse_ops.releasedir = FileSystem::ReleaseDir;
         fuse_ops.fsyncdir   = FileSystem::FSyncDir;
         fuse_ops.statfs     = FileSystem::StatFs;
-        #if FUSE_USE_VERSION > 28
+        #if FUSE_VERSION > 28
         #ifndef __APPLE__
         fuse_ops.forget_multi = FileSystem::MultiForget; 
         #endif
@@ -487,7 +487,7 @@ namespace NodeFuse {
 
     }
 
-    #if FUSE_USE_VERSION > 28
+    #if FUSE_VERSION > 28
     void FileSystem::MultiForget(fuse_req_t req,
                         size_t count,
                         struct fuse_forget_data *forget){
@@ -544,7 +544,7 @@ namespace NodeFuse {
         //scope.Close(Undefined());
 
     }
-    #endif //FUSE_USE_VERSION
+    #endif //FUSE_VERSION
 
 
     void FileSystem::Forget(fuse_req_t req,

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -96,7 +96,7 @@ namespace NodeFuse {
             static void Forget(fuse_req_t req,
                                 fuse_ino_t ino,
                                 unsigned long nlookup);
-            #if FUSE_USE_VERSION > 28
+            #if FUSE_VERSION > 28
             static void MultiForget(fuse_req_t req,
                                 size_t count,
                                 struct fuse_forget_data *forget_all);
@@ -250,7 +250,7 @@ namespace NodeFuse {
             static void RemoteForget(fuse_req_t req,
                                 fuse_ino_t ino,
                                 unsigned long nlookup);
-            #if FUSE_USE_VERSION > 28
+            #if FUSE_VERSION > 28
             static void RemoteMultiForget(fuse_req_t req,
                                 size_t count,
                                 struct fuse_forget_data *forget_all);

--- a/src/forget_data.cc
+++ b/src/forget_data.cc
@@ -1,5 +1,5 @@
 #include "forget_data.h"
-#if FUSE_USE_VERSION > 28
+#if FUSE_VERSION > 28
 
 namespace NodeFuse {
 

--- a/src/forget_data.h
+++ b/src/forget_data.h
@@ -5,8 +5,9 @@
 #ifndef SRC_FORGET_DATA_H_
 #define SRC_FORGET_DATA_H_
 
-#if FUSE_USE_VERSION > 28 
 #include "node_fuse.h"
+
+#if FUSE_VERSION > 28 
 
 namespace NodeFuse {
     class ForgetData : public ObjectWrap {
@@ -31,6 +32,6 @@ namespace NodeFuse {
 } //namespace NodeFuse
 
 
-#endif // if FUSE_USE_VERSION
+#endif // if FUSE_VERSION
 
 #endif  // ifdef SRC_FILE_INFO_H

--- a/src/node_fuse.cc
+++ b/src/node_fuse.cc
@@ -18,7 +18,7 @@ namespace NodeFuse {
         Reply::Initialize(target);
         FileInfo::Initialize(target);
 
-        #if FUSE_USE_VERSION > 28
+        #if FUSE_VERSION > 28
         #ifndef __APPLE__
         ForgetData::Initialize(target);
         #endif 
@@ -165,7 +165,7 @@ namespace NodeFuse {
         context->Set( Nan::New<String>("gid").ToLocalChecked(), Nan::New<Integer>(ctx->gid));
         context->Set( Nan::New<String>("pid").ToLocalChecked(), Nan::New<Integer>(ctx->pid));
 
-        #if FUSE_USE_VERSION > 28 && !__APPLE__
+        #if FUSE_VERSION > 28 && !__APPLE__
 
         context->Set( Nan::New<String>("umask").ToLocalChecked(), Nan::New<Integer>(ctx->umask));
         #endif


### PR DESCRIPTION
Certain functionality are fuse version dependent.
The proper macro to check is fuse_version.