### PR TITLE
Use Persistent symbols for access objects

### DIFF
--- a/src/file_info.cc
+++ b/src/file_info.cc
@@ -9,6 +9,38 @@
 
 namespace NodeFuse {
     Nan::Persistent<Function> FileInfo::constructor;
+    
+    static Nan::Persistent<String> flags_sym;
+    static Nan::Persistent<String> writepage_sym;
+    static Nan::Persistent<String> direct_io_sym;
+    static Nan::Persistent<String> keep_cache_sym;
+    static Nan::Persistent<String> flush_sym;
+    static Nan::Persistent<String> nonseekable_sym;
+    static Nan::Persistent<String> file_handle_sym;
+    static Nan::Persistent<String> lock_owner_sym;
+
+    //Open flags
+    static Nan::Persistent<String> rdonly_sym;
+    static Nan::Persistent<String> wronly_sym;
+    static Nan::Persistent<String> rdwr_sym;
+    static Nan::Persistent<String> nonblock_sym;
+    static Nan::Persistent<String> append_sym;
+    static Nan::Persistent<String> creat_sym;
+    static Nan::Persistent<String> trunc_sym;
+    static Nan::Persistent<String> excl_sym;
+#ifdef O_SHLOCK
+    static Nan::Persistent<String> shlock_sym;
+#endif
+#ifdef O_EXLOCK
+    static Nan::Persistent<String> exlock_sym;
+#endif
+    static Nan::Persistent<String> nofollow_sym;
+#ifdef O_SYMLINK
+    static Nan::Persistent<String> symlink_sym;
+#endif
+#ifdef O_EVTONLY
+    static Nan::Persistent<String> evtonly_sym;
+#endif
 
     NAN_METHOD(FileInfo::New){
         if (info.IsConstructCall()) {
@@ -24,37 +56,37 @@ namespace NodeFuse {
     }
 
     void FileInfo::Initialize(Handle<Object> target) {
-        /*
-        flags_sym = Nan::Global<String>( Nan::New("flags").ToLocalChecked());
-        writepage_sym = Nan::Global<String>( Nan::New("writepage").ToLocalChecked());
-        direct_io_sym = Nan::Global<String>( Nan::New("direct_io").ToLocalChecked());
-        keep_cache_sym = Nan::Global<String>( Nan::New("keep_cache").ToLocalChecked());
-        flush_sym = Nan::Global<String>( Nan::New("flush").ToLocalChecked());
-        nonseekable_sym = Nan::Global<String>( Nan::New("nonseekable").ToLocalChecked());
-        file_handle_sym = Nan::Global<String>( Nan::New("fh").ToLocalChecked());
-        lock_owner_sym = Nan::Global<String>( Nan::New("lock_owner").ToLocalChecked());
-        rdonly_sym = Nan::Global<String>( Nan::New("rdonly").ToLocalChecked());
-        wronly_sym = Nan::Global<String>( Nan::New("wronly").ToLocalChecked());
-        rdwr_sym = Nan::Global<String>( Nan::New("rdwr").ToLocalChecked());
-        nonblock_sym = Nan::Global<String>( Nan::New("nonblock").ToLocalChecked());
-        append_sym = Nan::Global<String>( Nan::New("append").ToLocalChecked());
-        creat_sym = Nan::Global<String>( Nan::New("creat").ToLocalChecked());
-        trunc_sym = Nan::Global<String>( Nan::New("trunc").ToLocalChecked());
-        excl_sym = Nan::Global<String>( Nan::New("excl").ToLocalChecked());
+        
+        flags_sym.Reset( Nan::New("flags").ToLocalChecked());
+        writepage_sym.Reset( Nan::New("writepage").ToLocalChecked());
+        direct_io_sym.Reset( Nan::New("direct_io").ToLocalChecked());
+        keep_cache_sym.Reset( Nan::New("keep_cache").ToLocalChecked());
+        flush_sym.Reset( Nan::New("flush").ToLocalChecked());
+        nonseekable_sym.Reset( Nan::New("nonseekable").ToLocalChecked());
+        file_handle_sym.Reset( Nan::New("file_handle").ToLocalChecked());
+        lock_owner_sym.Reset( Nan::New("lock_owner").ToLocalChecked());
+        rdonly_sym.Reset( Nan::New("rdonly").ToLocalChecked());
+        wronly_sym.Reset( Nan::New("wronly").ToLocalChecked());
+        rdwr_sym.Reset( Nan::New("rdwr").ToLocalChecked());
+        nonblock_sym.Reset( Nan::New("nonblock").ToLocalChecked());
+        append_sym.Reset( Nan::New("append").ToLocalChecked());
+        creat_sym.Reset( Nan::New("creat").ToLocalChecked());
+        trunc_sym.Reset( Nan::New("trunc").ToLocalChecked());
+        excl_sym.Reset( Nan::New("excl").ToLocalChecked());
         #ifdef O_SHLOCK
-        shlock_sym = Nan::Global<String>( Nan::New("shlock").ToLocalChecked());
+        shlock_sym.Reset( Nan::New("shlock").ToLocalChecked());
         #endif
         #ifdef O_EXLOCK
-        exlock_sym = Nan::Global<String>( Nan::New("exlock").ToLocalChecked());
+        exlock_sym.Reset( Nan::New("exlock").ToLocalChecked());
         #endif
-        nofollow_sym = Nan::Global<String>( Nan::New("nofollow").ToLocalChecked());
+        nofollow_sym.Reset( Nan::New("nofollow").ToLocalChecked());
         #ifdef O_SYMLINK
-        symlink_sym = Nan::Global<String>( Nan::New("symlink").ToLocalChecked());
+        symlink_sym.Reset( Nan::New("symlink").ToLocalChecked());
         #endif
         #ifdef O_EVTONLY
-        evtonly_sym = Nan::Global<String>( Nan::New("evtonly").ToLocalChecked());
+        evtonly_sym.Reset( Nan::New("evtonly").ToLocalChecked());
         #endif
-        */
+        
         Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
         tpl->SetClassName(Nan::New<v8::String>("FileInfo").ToLocalChecked());
         tpl->InstanceTemplate()->SetInternalFieldCount(1);
@@ -63,14 +95,14 @@ namespace NodeFuse {
 
         object_tmpl->SetInternalFieldCount(1);
 
-        Nan::SetAccessor(object_tmpl, Nan::New("flags").ToLocalChecked(), FileInfo::GetFlags);
-        Nan::SetAccessor(object_tmpl, Nan::New("writepage").ToLocalChecked(), FileInfo::GetWritePage);
-        Nan::SetAccessor(object_tmpl, Nan::New("direct_io").ToLocalChecked(), FileInfo::GetDirectIO, FileInfo::SetDirectIO);
-        Nan::SetAccessor(object_tmpl, Nan::New("keep_cache").ToLocalChecked(), FileInfo::GetKeepCache, FileInfo::SetKeepCache);
-        Nan::SetAccessor(object_tmpl, Nan::New("flush").ToLocalChecked(), FileInfo::GetFlush);
-        Nan::SetAccessor(object_tmpl, Nan::New("nonseekable").ToLocalChecked(), FileInfo::GetNonSeekable, FileInfo::SetNonSeekable);
-        Nan::SetAccessor(object_tmpl, Nan::New("file_handle").ToLocalChecked(), FileInfo::GetFileHandle, FileInfo::SetFileHandle);
-        Nan::SetAccessor(object_tmpl, Nan::New("lock_owner").ToLocalChecked(), FileInfo::GetLockOwner);
+        Nan::SetAccessor(object_tmpl, Nan::New(flags_sym), FileInfo::GetFlags);
+        Nan::SetAccessor(object_tmpl, Nan::New(writepage_sym), FileInfo::GetWritePage);
+        Nan::SetAccessor(object_tmpl, Nan::New(direct_io_sym), FileInfo::GetDirectIO, FileInfo::SetDirectIO);
+        Nan::SetAccessor(object_tmpl, Nan::New(keep_cache_sym), FileInfo::GetKeepCache, FileInfo::SetKeepCache);
+        Nan::SetAccessor(object_tmpl, Nan::New(flush_sym), FileInfo::GetFlush);
+        Nan::SetAccessor(object_tmpl, Nan::New(nonseekable_sym), FileInfo::GetNonSeekable, FileInfo::SetNonSeekable);
+        Nan::SetAccessor(object_tmpl, Nan::New(file_handle_sym), FileInfo::GetFileHandle, FileInfo::SetFileHandle);
+        Nan::SetAccessor(object_tmpl, Nan::New(lock_owner_sym), FileInfo::GetLockOwner);
         constructor.Reset(tpl->GetFunction());
 
     }
@@ -89,26 +121,26 @@ namespace NodeFuse {
         Local<Object> flagsObj = Nan::New<Object>();
 
         //Initializes object
-        Nan::Set(flagsObj, Nan::New("rdonly").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("wronly").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("rdwr").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("nonblock").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("append").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("creat").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("trunc").ToLocalChecked(), Nan::False());
-        Nan::Set(flagsObj, Nan::New("excl").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(rdonly_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(wronly_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(rdwr_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(nonblock_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(append_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(creat_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(trunc_sym), Nan::False());
+        Nan::Set(flagsObj, Nan::New(excl_sym), Nan::False());
 #ifdef O_SHLOCK
-        Nan::Set(flagsObj, Nan::New("shlock").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(shlock_sym), Nan::False());
 #endif
 #ifdef O_EXLOCK
-        Nan::Set(flagsObj, Nan::New("exlock").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(exlock_sym), Nan::False());
 #endif
-        Nan::Set(flagsObj, Nan::New("nofollow").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(nofollow_sym), Nan::False());
 #ifdef O_SYMLINK
-        Nan::Set(flagsObj, Nan::New("symlink").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(symlink_sym), Nan::False());
 #endif
 #ifdef O_EVTONLY
-        Nan::Set(flagsObj, Nan::New("evtonly").ToLocalChecked(), Nan::False());
+        Nan::Set(flagsObj, Nan::New(evtonly_sym), Nan::False());
 #endif
         /*
            O_RDONLY        open for reading only
@@ -130,60 +162,60 @@ namespace NodeFuse {
 
         switch( flags & 3){
             case 0:
-                Nan::Set(flagsObj, Nan::New("rdonly").ToLocalChecked(), Nan::True());
+                Nan::Set(flagsObj, Nan::New(rdonly_sym), Nan::True());
                 break;
             case 1:
-                Nan::Set(flagsObj, Nan::New("wronly").ToLocalChecked(), Nan::True());
+                Nan::Set(flagsObj, Nan::New(wronly_sym), Nan::True());
                 break;
             case 2:
-                Nan::Set(flagsObj, Nan::New("rdwr").ToLocalChecked(), Nan::True());
+                Nan::Set(flagsObj, Nan::New(rdwr_sym), Nan::True());
                 break;
         }
         if (flags & O_NONBLOCK) {
-            Nan::Set(flagsObj, Nan::New("nonblock").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(nonblock_sym), Nan::True());
         }
 
         if (flags & O_APPEND) {
-            Nan::Set(flagsObj, Nan::New("append").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(append_sym), Nan::True());
         }
 
         if (flags & O_CREAT) {
-            Nan::Set(flagsObj, Nan::New("creat").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(creat_sym), Nan::True());
         }
 
         if (flags & O_TRUNC) {
-            Nan::Set(flagsObj, Nan::New("trunc").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(trunc_sym), Nan::True());
         }
 
         if (flags & O_EXCL) {
-            Nan::Set(flagsObj, Nan::New("excl").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(excl_sym), Nan::True());
         }
 
 #ifdef O_SHLOCK
         if (flags & O_SHLOCK) {
-            Nan::Set(flagsObj, Nan::New("shlock").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(shlock_sym), Nan::True());
         }
 #endif
 
 #ifdef O_EXLOCK
         if (flags & O_EXLOCK) {
-            Nan::Set(flagsObj, Nan::New("exlock").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(exlock_sym), Nan::True());
         }
 #endif
 
         if (flags & O_NOFOLLOW) {
-            Nan::Set(flagsObj, Nan::New("nofollow").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(nofollow_sym), Nan::True());
         }
 
 #ifdef O_SYMLINK
         if (flags & O_SYMLINK) {
-            Nan::Set(flagsObj, Nan::New("symlink").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(symlink_sym), Nan::True());
         }
 #endif
 
 #ifdef O_EVTONLY
         if (flags & O_EVTONLY) {
-            Nan::Set(flagsObj, Nan::New("evtonly").ToLocalChecked(), Nan::True());
+            Nan::Set(flagsObj, Nan::New(evtonly_sym), Nan::True());
         }
 #endif
 

--- a/src/node_fuse.cc
+++ b/src/node_fuse.cc
@@ -9,10 +9,89 @@
 #include "forget_data.h"
 namespace NodeFuse {
     //stat struct symbols
+    
+    static Nan::Persistent<String> uid_sym;
+    static Nan::Persistent<String> gid_sym;
+    static Nan::Persistent<String> pid_sym;
+    static Nan::Persistent<String> dev_sym;
+    static Nan::Persistent<String> mode_sym;
+    static Nan::Persistent<String> nlink_sym;
+    static Nan::Persistent<String> rdev_sym;
+    static Nan::Persistent<String> size_sym;
+    static Nan::Persistent<String> blksize_sym;
+    static Nan::Persistent<String> blocks_sym;
+    static Nan::Persistent<String> atime_sym;
+    static Nan::Persistent<String> mtime_sym;
+    static Nan::Persistent<String> ctime_sym;
+
+    //statvfs struct symbols
+    static Nan::Persistent<String> bsize_sym;
+    static Nan::Persistent<String> frsize_sym;
+    //static Nan::Persistent<String> blocks_sym;
+    static Nan::Persistent<String> bfree_sym;
+    static Nan::Persistent<String> bavail_sym;
+    static Nan::Persistent<String> files_sym;
+    static Nan::Persistent<String> ffree_sym;
+    static Nan::Persistent<String> favail_sym;
+    static Nan::Persistent<String> fsid_sym;
+    static Nan::Persistent<String> flag_sym;
+    static Nan::Persistent<String> namemax_sym;
+
+    //entry symbols
+    static Nan::Persistent<String> ino_sym;
+    static Nan::Persistent<String> generation_sym;
+    static Nan::Persistent<String> attr_sym;
+    static Nan::Persistent<String> attr_timeout_sym;
+    static Nan::Persistent<String> entry_timeout_sym;
+
+    //lock symbols
+    static Nan::Persistent<String> type_sym;
+    static Nan::Persistent<String> whence_sym;
+    static Nan::Persistent<String> start_sym;
+    static Nan::Persistent<String> len_sym;
+    static Nan::Persistent<String> umask_sym;
+    //static Nan::Persistent<String> pid_sym;
+
 
     void InitializeFuse(Handle<Object> target) {
         Nan::HandleScope scope;;
-
+        
+        /* Initialize persistent references */
+        uid_sym.Reset( Nan::New<String>("uid").ToLocalChecked());
+        gid_sym.Reset( Nan::New<String>("gid").ToLocalChecked());
+        pid_sym.Reset( Nan::New<String>("pid").ToLocalChecked());
+        dev_sym.Reset( Nan::New<String>("dev").ToLocalChecked());
+        mode_sym.Reset( Nan::New<String>("mode").ToLocalChecked());
+        nlink_sym.Reset( Nan::New<String>("nlink").ToLocalChecked());
+        rdev_sym.Reset( Nan::New<String>("rdev").ToLocalChecked());
+        size_sym.Reset( Nan::New<String>("size").ToLocalChecked());
+        blksize_sym.Reset( Nan::New<String>("blksize").ToLocalChecked());
+        blocks_sym.Reset( Nan::New<String>("blocks").ToLocalChecked());
+        atime_sym.Reset( Nan::New<String>("atime").ToLocalChecked());
+        mtime_sym.Reset( Nan::New<String>("mtime").ToLocalChecked());
+        ctime_sym.Reset( Nan::New<String>("ctime").ToLocalChecked());
+        bsize_sym.Reset( Nan::New<String>("bsize").ToLocalChecked());
+        frsize_sym.Reset( Nan::New<String>("frsize").ToLocalChecked());
+        blocks_sym.Reset( Nan::New<String>("blocks").ToLocalChecked());
+        bfree_sym.Reset( Nan::New<String>("bfree").ToLocalChecked());
+        bavail_sym.Reset( Nan::New<String>("bavail").ToLocalChecked());
+        files_sym.Reset( Nan::New<String>("files").ToLocalChecked());
+        ffree_sym.Reset( Nan::New<String>("ffree").ToLocalChecked());
+        favail_sym.Reset( Nan::New<String>("favail").ToLocalChecked());
+        fsid_sym.Reset( Nan::New<String>("fsid").ToLocalChecked());
+        flag_sym.Reset( Nan::New<String>("flag").ToLocalChecked());
+        namemax_sym.Reset( Nan::New<String>("namemax").ToLocalChecked());
+        ino_sym.Reset( Nan::New<String>("inode").ToLocalChecked());
+        generation_sym.Reset( Nan::New<String>("generation").ToLocalChecked());
+        attr_sym.Reset( Nan::New<String>("attr").ToLocalChecked());
+        attr_timeout_sym.Reset( Nan::New<String>("attr_timeout").ToLocalChecked());
+        entry_timeout_sym.Reset( Nan::New<String>("entry_timeout").ToLocalChecked());
+        type_sym.Reset( Nan::New<String>("type").ToLocalChecked());
+        whence_sym.Reset( Nan::New<String>("whence").ToLocalChecked());
+        start_sym.Reset( Nan::New<String>("start").ToLocalChecked());
+        len_sym.Reset( Nan::New<String>("len").ToLocalChecked());
+        pid_sym.Reset( Nan::New<String>("pid").ToLocalChecked());
+        umask_sym.Reset( Nan::New<String>("umask").ToLocalChecked());
         Fuse::Initialize(target);
         FileSystem::Initialize(target);
         Reply::Initialize(target);
@@ -39,13 +118,13 @@ namespace NodeFuse {
         memset(entry, 0, sizeof(struct fuse_entry_param));
 
         Local<Object> obj = value->ToObject();
-        entry->ino = obj->Get(Nan::New<String>("inode").ToLocalChecked())->IntegerValue();
-        entry->generation = obj->Get(Nan::New<String>("generation").ToLocalChecked())->IntegerValue();
-        entry->attr_timeout = obj->Get(Nan::New<String>("attr_timeout").ToLocalChecked())->NumberValue();
-        entry->entry_timeout = obj->Get(Nan::New<String>("entry_timeout").ToLocalChecked())->NumberValue();
+        entry->ino = obj->Get(Nan::New(ino_sym))->IntegerValue();
+        entry->generation = obj->Get(Nan::New(generation_sym))->IntegerValue();
+        entry->attr_timeout = obj->Get(Nan::New(attr_timeout_sym))->IntegerValue();
+        entry->entry_timeout = obj->Get(Nan::New(entry_timeout_sym))->IntegerValue();
 
         //struct stat statbuf;
-        ret = ObjectToStat(obj->Get(Nan::New<String>("attr").ToLocalChecked()), &entry->attr);
+        ret = ObjectToStat(obj->Get(Nan::New(attr_sym)), &entry->attr);
 
         return ret;
     }
@@ -57,21 +136,26 @@ namespace NodeFuse {
 
         Local<Object> obj = value->ToObject();
 
-        statbuf->st_dev = obj->Get(Nan::New<String>("dev").ToLocalChecked())->IntegerValue();
-        // statbuf->st_dev = Nan::Get(obj, Nan::New<String>("dev").ToLocalChecked())->IntegerValue();
-        statbuf->st_ino = obj->Get(Nan::New<String>("inode").ToLocalChecked())->IntegerValue();
-        // statbuf->st_ino = Nan::GetRealNamedProperty(obj, Nan::New<String>("inode").ToLocalChecked()).ToLocalChecked()->IntegerValue();
-        statbuf->st_mode = obj->Get(Nan::New<String>("mode").ToLocalChecked())->IntegerValue();
-        statbuf->st_nlink = obj->Get(Nan::New<String>("nlink").ToLocalChecked())->IntegerValue();
-        statbuf->st_uid = obj->Get(Nan::New<String>("uid").ToLocalChecked())->IntegerValue();
-        statbuf->st_gid = obj->Get(Nan::New<String>("gid").ToLocalChecked())->IntegerValue();
-        statbuf->st_rdev = obj->Get(Nan::New<String>("rdev").ToLocalChecked())->IntegerValue();
-        statbuf->st_size = obj->Get(Nan::New<String>("size").ToLocalChecked())->NumberValue();
-        statbuf->st_blksize = obj->Get(Nan::New<String>("blksize").ToLocalChecked())->IntegerValue();
-        statbuf->st_blocks = obj->Get(Nan::New<String>("blocks").ToLocalChecked())->IntegerValue();
-        statbuf->st_atime = obj->Get(Nan::New<String>("atime").ToLocalChecked())->IntegerValue();
-        statbuf->st_mtime = obj->Get(Nan::New<String>("mtime").ToLocalChecked())->IntegerValue();
-        statbuf->st_ctime = obj->Get(Nan::New<String>("ctime").ToLocalChecked())->IntegerValue();
+        statbuf->st_dev = obj->Get(Nan::New(dev_sym))->IntegerValue();
+        // statbuf->st_dev = Nan::Get(obj, Nan::New(dev_sym).ToLocalChecked())->IntegerValue();
+        statbuf->st_ino = obj->Get(Nan::New(ino_sym))->IntegerValue();
+        // statbuf->st_ino = Nan::GetRealNamedProperty(obj, Nan::New(inode_sym).ToLocalChecked()).ToLocalChecked()->IntegerValue();
+        statbuf->st_mode = obj->Get(Nan::New(mode_sym))->IntegerValue();
+        statbuf->st_nlink = obj->Get(Nan::New(nlink_sym))->IntegerValue();
+        statbuf->st_uid = obj->Get(Nan::New(uid_sym))->IntegerValue();
+        statbuf->st_gid = obj->Get(Nan::New(gid_sym))->IntegerValue();
+        statbuf->st_rdev = obj->Get(Nan::New(rdev_sym))->IntegerValue();
+        statbuf->st_size = obj->Get(Nan::New(size_sym))->IntegerValue();
+        // Local<String> sizeStr = obj->Get(Nan::New(size_sym))->ToString();
+        // Nan::Utf8String sizeBuf(sizeStr);
+        // statbuf->st_size = atoll( *sizeBuf );
+
+        statbuf->st_blksize = obj->Get(Nan::New(blksize_sym))->IntegerValue();
+        statbuf->st_blocks = obj->Get(Nan::New(blocks_sym))->IntegerValue();
+        statbuf->st_atime = obj->Get(Nan::New(atime_sym))->IntegerValue();
+        statbuf->st_mtime = obj->Get(Nan::New(mtime_sym))->IntegerValue();
+        statbuf->st_ctime = obj->Get(Nan::New(ctime_sym))->IntegerValue();
+
 
         return 0;
     }
@@ -83,19 +167,19 @@ namespace NodeFuse {
 
         Local<Object> obj = value->ToObject();
 
-        statbuf->f_bsize = obj->Get(Nan::New<String>("bsize").ToLocalChecked())->NumberValue();
-        statbuf->f_frsize = obj->Get(Nan::New<String>("blocks").ToLocalChecked())->NumberValue();
+        statbuf->f_bsize = obj->Get(Nan::New(bsize_sym))->IntegerValue();
+        statbuf->f_frsize = obj->Get(Nan::New(blocks_sym))->IntegerValue();
 
-        statbuf->f_blocks = obj->Get(Nan::New<String>("blocks").ToLocalChecked())->IntegerValue();
-        statbuf->f_bfree = obj->Get(Nan::New<String>("bfree").ToLocalChecked())->IntegerValue();
-        statbuf->f_bavail = obj->Get(Nan::New<String>("bavail").ToLocalChecked())->IntegerValue();
-        statbuf->f_files = obj->Get(Nan::New<String>("files").ToLocalChecked())->IntegerValue();
-        statbuf->f_ffree = obj->Get(Nan::New<String>("ffree").ToLocalChecked())->IntegerValue();
-        statbuf->f_favail = obj->Get(Nan::New<String>("favail").ToLocalChecked())->NumberValue();
+        statbuf->f_blocks = obj->Get(Nan::New(blocks_sym))->IntegerValue();
+        statbuf->f_bfree = obj->Get(Nan::New(bfree_sym))->IntegerValue();
+        statbuf->f_bavail = obj->Get(Nan::New(bavail_sym))->IntegerValue();
+        statbuf->f_files = obj->Get(Nan::New(files_sym))->IntegerValue();
+        statbuf->f_ffree = obj->Get(Nan::New(ffree_sym))->IntegerValue();
+        statbuf->f_favail = obj->Get(Nan::New(favail_sym))->IntegerValue();
 
-        statbuf->f_fsid = obj->Get(Nan::New<String>("fsid").ToLocalChecked())->NumberValue();
-        statbuf->f_flag = obj->Get(Nan::New<String>("flag").ToLocalChecked())->NumberValue();
-        statbuf->f_namemax = obj->Get(Nan::New<String>("namemax").ToLocalChecked())->NumberValue();
+        statbuf->f_fsid = obj->Get(Nan::New(fsid_sym))->IntegerValue();
+        statbuf->f_flag = obj->Get(Nan::New(flag_sym))->IntegerValue();
+        statbuf->f_namemax = obj->Get(Nan::New(namemax_sym))->IntegerValue();
 
         return 0;
     }
@@ -107,11 +191,11 @@ namespace NodeFuse {
 
         Local<Object> obj = value->ToObject();
 
-        lock->l_type = obj->Get(Nan::New<String>("type").ToLocalChecked())->IntegerValue();
-        lock->l_whence = obj->Get(Nan::New<String>("whence").ToLocalChecked())->IntegerValue();
-        lock->l_start = obj->Get(Nan::New<String>("start").ToLocalChecked())->IntegerValue();
-        lock->l_len = obj->Get(Nan::New<String>("len").ToLocalChecked())->IntegerValue();
-        lock->l_pid = obj->Get(Nan::New<String>("pid").ToLocalChecked())->IntegerValue();
+        lock->l_type = obj->Get(Nan::New(type_sym))->IntegerValue();
+        lock->l_whence = obj->Get(Nan::New(whence_sym))->IntegerValue();
+        lock->l_start = obj->Get(Nan::New(start_sym))->IntegerValue();
+        lock->l_len = obj->Get(Nan::New(len_sym))->IntegerValue();
+        lock->l_pid = obj->Get(Nan::New(pid_sym))->IntegerValue();
 
         return 0;
     }
@@ -120,36 +204,36 @@ namespace NodeFuse {
         Local<Object> attrs = Nan::New<Object>();
 
         if (to_set & FUSE_SET_ATTR_MODE) {
-            attrs->Set( Nan::New<String>("mode").ToLocalChecked(), Nan::New<Integer>(stat->st_mode));
+            attrs->Set( Nan::New(mode_sym), Nan::New<Integer>(stat->st_mode));
         }
 
         if (to_set & FUSE_SET_ATTR_UID) {
-            attrs->Set( Nan::New<String>("uid").ToLocalChecked(), Nan::New<Integer>(stat->st_uid));
+            attrs->Set( Nan::New(uid_sym), Nan::New<Integer>(stat->st_uid));
         }
 
         if (to_set & FUSE_SET_ATTR_GID) {
-            attrs->Set( Nan::New<String>("gid").ToLocalChecked(), Nan::New<Integer>(stat->st_gid));
+            attrs->Set( Nan::New(gid_sym), Nan::New<Integer>(stat->st_gid));
         }
 
         if (to_set & FUSE_SET_ATTR_SIZE) {
-            attrs->Set( Nan::New<String>("size").ToLocalChecked(), Nan::New<Number>(stat->st_size));
+            attrs->Set( Nan::New(size_sym), Nan::New<Number>((double)stat->st_size));
         }
 
         if (to_set & FUSE_SET_ATTR_ATIME) {
-            attrs->Set( Nan::New<String>("atime").ToLocalChecked(), NODE_UNIXTIME_V8(stat->st_atime));
+            attrs->Set( Nan::New(atime_sym), NODE_UNIXTIME_V8(stat->st_atime));
         }
 
         if (to_set & FUSE_SET_ATTR_MTIME) {
-            attrs->Set( Nan::New<String>("mtime").ToLocalChecked(), NODE_UNIXTIME_V8(stat->st_mtime));
+            attrs->Set( Nan::New(mtime_sym), NODE_UNIXTIME_V8(stat->st_mtime));
         }
 
         #ifdef FUSE_SET_ATTR_ATIME_NOW
         if (to_set & FUSE_SET_ATTR_ATIME_NOW ){
-            attrs->Set( Nan::New<String>("atime").ToLocalChecked(), Nan::New<Integer>(-1));
+            attrs->Set( Nan::New(atime_sym), Nan::New<Integer>(-1));
         }
 
         if (to_set & FUSE_SET_ATTR_MTIME_NOW ){
-            attrs->Set( Nan::New<String>("mtime").ToLocalChecked(), Nan::New<Integer>(-1));
+            attrs->Set( Nan::New(mtime_sym), Nan::New<Integer>(-1));
         }
         #endif
 
@@ -161,13 +245,13 @@ namespace NodeFuse {
     Handle<Value> RequestContextToObject(const struct fuse_ctx* ctx) {
         Local<Object> context = Nan::New<Object>();
 
-        context->Set( Nan::New<String>("uid").ToLocalChecked(), Nan::New<Integer>(ctx->uid));
-        context->Set( Nan::New<String>("gid").ToLocalChecked(), Nan::New<Integer>(ctx->gid));
-        context->Set( Nan::New<String>("pid").ToLocalChecked(), Nan::New<Integer>(ctx->pid));
+        context->Set( Nan::New(uid_sym), Nan::New<Integer>(ctx->uid));
+        context->Set( Nan::New(gid_sym), Nan::New<Integer>(ctx->gid));
+        context->Set( Nan::New(pid_sym), Nan::New<Integer>(ctx->pid));
 
         #if FUSE_VERSION > 28 && !__APPLE__
 
-        context->Set( Nan::New<String>("umask").ToLocalChecked(), Nan::New<Integer>(ctx->umask));
+        context->Set( Nan::New(umask_sym), Nan::New<Integer>(ctx->umask));
         #endif
 
         return context;
@@ -177,12 +261,12 @@ namespace NodeFuse {
         Local<Object> rv = Nan::New<Object>();
 
         //Specifies the type of the lock; one of F_RDLCK, F_WRLCK, or F_UNLCK.
-        rv->Set( Nan::New<String>("type").ToLocalChecked(), Nan::New<Integer>(lock->l_type)); //TODO convert to object with accessors
+        rv->Set( Nan::New(type_sym), Nan::New<Integer>(lock->l_type)); //TODO convert to object with accessors
         //This corresponds to the whence argument to fseek or lseek, and specifies what the offset is relative to. Its value can be one of SEEK_SET, SEEK_CUR, or SEEK_END.
-        rv->Set( Nan::New<String>("whence").ToLocalChecked(), Nan::New<Integer>(lock->l_whence)); //TODO convert to object with accessors
-        rv->Set( Nan::New<String>("start").ToLocalChecked(), Nan::New<Integer>( (int) lock->l_start));
-        rv->Set( Nan::New<String>("len").ToLocalChecked(), Nan::New<Integer>( (int) lock->l_len));
-        rv->Set( Nan::New<String>("pid").ToLocalChecked(), Nan::New<Integer>( (int) lock->l_pid));
+        rv->Set( Nan::New(whence_sym), Nan::New<Integer>(lock->l_whence)); //TODO convert to object with accessors
+        rv->Set( Nan::New(start_sym), Nan::New<Integer>( (int) lock->l_start));
+        rv->Set( Nan::New(len_sym), Nan::New<Integer>( (int) lock->l_len));
+        rv->Set( Nan::New(pid_sym), Nan::New<Integer>( (int) lock->l_pid));
 
         return rv;
     }


### PR DESCRIPTION
Prior to me taking over the project, the attributes of file_info objects were accessed by persistent objects instead of creating a new string object every time.
However, due to the changes from nan v1 to nan v2, it was not clear to me how persistent objects were assigned. Now, I have a much better understanding of persistent objects in v8 and I have brought them back.
