### PR TITLE
Persistent and v8 fix

### DIFF
--- a/examples/loopback.js
+++ b/examples/loopback.js
@@ -9,89 +9,95 @@ const pth = require('path');
 const fs = require('fs');
 // since the inodes need to be unique, 
 // we need to keep track of the inodes and it's associated path
-const pathToInode = new Map(); 
+const pathToInode = new Map();
 const inodeToPath = new Map();
-inodeToPath.set( 1, '/');
+inodeToPath.set(1, '/');
 var next_largest_inode = 2;
 
 // variable to store the loopback folder
 // this will be set later
-var loopbackFolder = ""; 
+var loopbackFolder = "";
 
 class LoopbackFS extends FileSystem {
-    lookup(context, parentInode, name, reply){
+    lookup(context, parentInode, name, reply) {
 
         // get the parent path
         const parent = inodeToPath.get(parentInode);
 
         // make sure it exists
-        if( !parent ){
+        if (!parent) {
             reply.err(PosixError.ENOENT);
             return;
         }
 
         // get the full folder path
-        const localPath = pth.join(parent,name);
+        const localPath = pth.join(parent, name);
         const path = pth.join(loopbackFolder, parent, name);
 
         // get the file information 
-        fs.stat( path, function(err, stat){
-            if(err){
+        try {
+            // use sync such that tests can pass. otherwise, use async
+            var stat = fs.statSync(path);
+        } catch (err) {
+            reply.err(-err.errno);
+            return;
+        }
+
+        // check to see if the path has been visited before.
+        // if not, add it to the map
+        var inode = 0;
+        if (!pathToInode.has(localPath)) {
+            inode = next_largest_inode;
+            pathToInode.set(localPath, inode);
+            inodeToPath.set(inode, localPath);
+            next_largest_inode++;
+        } else {
+            inode = pathToInode.get(localPath);
+        }
+
+        stat.inode = stat.ino;
+        const entry = {
+            inode,
+            attr: stat,
+            generation: 1 //some filesystems rely on this generation number, such as the  Network Filesystem
+        };
+
+        reply.entry(entry);
+
+
+    }
+
+    getattr(context, inode, reply) {
+        const localPath = inodeToPath.get(inode);
+        if (localPath) {
+            try {
+                // use sync such that tests can pass. otherwise, use async
+                var stat = fs.statSync(pth.join(loopbackFolder, localPath));
+                stat.inode = stat.ino;
+                reply.attr(stat, 5); //5, timeout value, in seconds, for the validity of this inode. so 5 seconds
+            } catch (err) {
                 reply.err(-err.errno);
                 return;
             }
 
-            // check to see if the path has been visited before.
-            // if not, add it to the map
-            var inode = 0;
-            if( ! pathToInode.has(localPath) ){
-                inode = next_largest_inode;
-                pathToInode[localPath] = inode;
-                inodeToPath[inode] = localPath;
-                next_largest_inode++;
-            }else{
-                inode = pathToInode.get(localPath);
-            }
 
-            stat.inode = stat.ino;
-            const entry = {
-                inode, 
-                attr: stat,
-                generation: 1 //some filesystems rely on this generation number, such as the  Network Filesystem
-            };
-
-        });
-
-    }
-
-    getattr(context, inode, reply){
-        const path = inodeToPath.get(inode);
-        if(path){
-            fs.stat(path, function(err,stat){
-                if(err){
-                    reply.err(-err.errno);
-                    return;
-                }
-                reply.attr(stat,5); //5, timeout value, in seconds, for the validity of this inode. so 5 seconds
-            });
-
-        }else{
-            reply.err(PosixError.ENOENT); 
+        } else {
+            reply.err(PosixError.ENOENT);
         }
         return;
     }
-    releasedir(context, inode, fileInfo, reply){
+    releasedir(context, inode, fileInfo, reply) {
         // console.log('Releasedir was called!');
         // console.log(fileInfo);
         reply.err(0);
     }
 
-    opendir(context, inode, fileInfo, reply){
+    opendir(context, inode, fileInfo, reply) {
         reply.open(fileInfo);
     }
 
 
-    readdir(context, inode, requestedSize, offset, fileInfo, reply){
+    readdir(context, inode, requestedSize, offset, fileInfo, reply) {
         //http://fuse.sourceforge.net/doxygen/structfuse__lowlevel__ops.html#af1ef8e59e0cb0b02dc0e406898aeaa51
         
         /*
@@ -108,33 +114,34 @@ class LoopbackFS extends FileSystem {
         */
 
         const folder = inodeToPath.get(inode);
-        if(!folder){
+        if (!folder) {
             reply.err(PosixError.ENOENT);
             return;
-        }        
+        }
 
         const path = pth.join(loopbackFolder, folder);
-        fs.readdir(path, function(err, files){
-
-            if(err){
+        fs.readdir(path, function (err, files) {
+            if (err) {
                 reply.err(-err.errno);
                 return;
             }
 
-            const size = Math.max( requestedSize , files.length * 256);
-            for( let file of files){
-                let attr = fs.lstatSync(pth.join(path, file));
-                attr.atime = attr.atime.getTime();
-                attr.mtime = attr.mtime.getTime();
-                attr.ctime = attr.ctime.getTime();
+            const size = Math.max(requestedSize, files.length * 256);
+            for (let file of files) {
+   
+                // use sync such that tests can pass. otherwise, use async
+                let attr = fs.statSync(pth.join(path, file));
+                attr.atime = Math.floor(attr.atime.getTime() / 1000);
+                attr.mtime = Math.floor(attr.mtime.getTime() / 1000);
+                attr.ctime = Math.floor(attr.ctime.getTime() / 1000);
+                attr.birthtime = Math.floor(attr.birthtime.getTime() / 1000);
                 attr.inode = attr.ino;
-                attr.birthtime = attr.birthtime.getTime();
 
                 // keep track of new inodes
-                if( !inodeToPath.has(attr.ino)){                    
+                if (!inodeToPath.has(attr.ino)) {
                     inodeToPath.set(attr.ino, pth.join(folder, file));
                 }
-                reply.addDirEntry(file, size, attr , offset);   
+                reply.addDirEntry(file, size, attr, offset);
             }
             reply.buffer(new Buffer(0), requestedSize)
 
@@ -142,13 +149,12 @@ class LoopbackFS extends FileSystem {
 
     }
 
-    open(context, inode, fileInfo, reply){
-        if(inode == 3)
-        {   
-            reply.open(fileInfo);       
+    open(context, inode, fileInfo, reply) {
+        if (inode == 3) {
+            reply.open(fileInfo);
             return;
         }
-        if(inode < 3){
+        if (inode < 3) {
             reply.err(PosixError.EISDIR);
             return;
         }
@@ -157,10 +163,10 @@ class LoopbackFS extends FileSystem {
 
     }
 
-    read(context, inode, len, offset, fileInfo, reply){
-        if(inode == 3){
+    read(context, inode, len, offset, fileInfo, reply) {
+        if (inode == 3) {
             const length = file_content.length
-            const content = file_content.substr(offset,Math.min(length, offset + len));
+            const content = file_content.substr(offset, Math.min(length, offset + len));
             reply.buffer(new Buffer(content), content.length);
             return;
         }
@@ -169,14 +175,15 @@ class LoopbackFS extends FileSystem {
         return;
     }
 
-    release(context, inode, fileInfo, reply){
+    release(context, inode, fileInfo, reply) {
         reply.err(0);
     }
 
 };
 
-function setLoopback(folder){
+function setLoopback(folder) {
     loopbackFolder = folder;
+    console.log(folder);
 }
 
-module.exports = {LoopbackFS, setLoopback};
+module.exports = { LoopbackFS, setLoopback };

--- a/src/bindings.cc
+++ b/src/bindings.cc
@@ -28,7 +28,7 @@ namespace NodeFuse {
 
     }
 
-    Fuse::Fuse() : ObjectWrap() {}
+    Fuse::Fuse() : Nan::ObjectWrap() {}
     Fuse::~Fuse() {
         if (fargs != NULL) {
             fuse_opt_free_args(fargs);
@@ -165,7 +165,7 @@ namespace NodeFuse {
         }
 
         Local<Object> currentInstance = info.This();
-        Fuse *fuse  = ObjectWrap::Unwrap<Fuse>(currentInstance);
+        Fuse *fuse  = Nan::ObjectWrap::Unwrap<Fuse>(currentInstance);
         struct fuse_args fargs = FUSE_ARGS_INIT(0, NULL);
         fuse->fargs = (struct fuse_args *)malloc(sizeof(fargs));
         memcpy( fuse->fargs, &fargs, sizeof(fargs) );   
@@ -225,7 +225,7 @@ namespace NodeFuse {
     void Fuse::Unmount(const Nan::FunctionCallbackInfo<v8::Value>& args) {
         Nan::EscapableHandleScope scope;
         Local<Object> currentInstance = args.This();
-        Fuse *fuse = ObjectWrap::Unwrap<Fuse>(currentInstance);
+        Fuse *fuse = Nan::ObjectWrap::Unwrap<Fuse>(currentInstance);
         // fuse_session_exit(fuse->session);
         // printf("unmount called");
         // fuse_session_remove_chan(fuse->channel);

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -6,7 +6,7 @@
 #include "node_fuse.h"
 
 namespace NodeFuse {
-    class Fuse : public ObjectWrap {
+    class Fuse : public Nan::ObjectWrap {
         public:
             static void Initialize(Handle<Object> target);
             Nan::Persistent<Object> fsobj;

--- a/src/file_info.cc
+++ b/src/file_info.cc
@@ -107,7 +107,7 @@ namespace NodeFuse {
 
     }
 
-    FileInfo::FileInfo() : ObjectWrap() {}
+    FileInfo::FileInfo() : Nan::ObjectWrap() {}
     FileInfo::~FileInfo() {
         // if(this->fi != nullptr)
         // {
@@ -117,7 +117,7 @@ namespace NodeFuse {
     }
 
     NAN_GETTER(FileInfo::GetFlags){
-        FileInfo* fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo* fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         Local<Object> flagsObj = Nan::New<Object>();
 
         //Initializes object
@@ -223,17 +223,17 @@ namespace NodeFuse {
     }
 
     NAN_GETTER(FileInfo::GetWritePage){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set(fileInfo->fi.writepage ? Nan::True() : Nan::False());
     }
 
     NAN_GETTER(FileInfo::GetDirectIO){//(Local<String> property, const AccessorInfo& info) {
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set(fileInfo->fi.direct_io ? Nan::True() : Nan::False());
     }
 
     NAN_SETTER(FileInfo::SetDirectIO){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
 
         if (!value->IsBoolean()) {
             // TODO: Check to see if this case will cause errors
@@ -244,12 +244,12 @@ namespace NodeFuse {
     }
 
     NAN_GETTER(FileInfo::GetKeepCache){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set(fileInfo->fi.keep_cache ? Nan::True() : Nan::False());
     }
 
     NAN_SETTER(FileInfo::SetKeepCache){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
 
         if (!value->IsBoolean()) {
             // TODO: Check to see if this case will cause errors
@@ -260,14 +260,14 @@ namespace NodeFuse {
     }
 
     NAN_GETTER(FileInfo::GetFlush){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set( fileInfo->fi.flush ? Nan::True() : Nan::False());
     }
 
     NAN_GETTER(FileInfo::GetNonSeekable){     
 
 #if FUSE_VERSION > 27 && !__APPLE__
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         info.GetReturnValue().Set(fileInfo->fi.nonseekable ? Nan::True() : Nan::False());
 #else
         info.GetReturnValue().Set(Nan::False());
@@ -280,13 +280,13 @@ namespace NodeFuse {
             FUSEJS_THROW_EXCEPTION("Invalid value type: ", "a Boolean was expected");
         }
 #if FUSE_VERSION > 28 && !__APPLE__
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
         fileInfo->fi.nonseekable = value->IsTrue() ? 1 : 0;
 #endif
     }
 
     NAN_SETTER(FileInfo::SetFileHandle){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
 
         if (!value->IsNumber()) {
             Nan::ThrowTypeError("Invalid value type: a Number was expected");        
@@ -296,13 +296,13 @@ namespace NodeFuse {
     }
 
     NAN_GETTER(FileInfo::GetFileHandle){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
 
         info.GetReturnValue().Set(Nan::New<Integer>(  (uint32_t) (fileInfo->fi.fh) ));
     }
 
     NAN_GETTER(FileInfo::GetLockOwner){
-        FileInfo *fileInfo = ObjectWrap::Unwrap<FileInfo>(info.This());
+        FileInfo *fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(info.This());
 
         info.GetReturnValue().Set(Nan::New<Integer>(  (uint32_t) (fileInfo->fi.lock_owner) ));
     }

--- a/src/file_info.h
+++ b/src/file_info.h
@@ -7,7 +7,7 @@
 #include "node_fuse.h"
 //https://github.com/nodejs/nan/blob/4ed41d760313b648b4d212d6ff5374668757be4f/test/cpp/settemplate.cpp
 namespace NodeFuse {
-    class FileInfo : public ObjectWrap {
+    class FileInfo : public Nan::ObjectWrap {
         friend class FileSystem;
         friend class Reply;
 

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -524,11 +524,12 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Array> data = Nan::New<Array>(count);
 
-        for( uint i = 0; i < count; i++){
+        // for( uint i = 0; i < count; i++){
             ForgetData *forget_data = new ForgetData();
             // forget_data->fd = &( forget_all[i] );
-            Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(forget_data->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-            data->Set(i, infoObj);
+            Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(forget_data->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+            FileInfo *data = Nan::ObjectWrap.Unwrap(i, infoObj);
+            info->fi = fi;
         }
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
@@ -1192,12 +1193,13 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info* ) malloc(sizeof(struct fuse_file_info));
         // memcpy( info->fi, &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1262,12 +1264,13 @@ namespace NodeFuse {
         Local<Number> size = Nan::New<Number>(size_);
         Local<Number> offset = Nan::New<Number>(off);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1340,13 +1343,14 @@ namespace NodeFuse {
         Local<Object> buffer = Nan::NewBuffer((char*) buf, size).ToLocalChecked();
         // free will be called implicitly when buffer is garbage collected
         // free((void *)buf);
-        FileInfo* info = new FileInfo();
+        // FileInfo* info = new FileInfo();
 
-        info->fi = fi;
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1402,14 +1406,15 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
         
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
-
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->FileInfo *Nan::ObjectWrap.Unwrap(= ;
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
+ 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
         Reply *reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
@@ -1463,12 +1468,13 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1526,13 +1532,14 @@ namespace NodeFuse {
         Local<Number> inode = Nan::New<Number>(ino);
         bool datasync = datasync_ == 0 ? false : true;
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
 
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->FileInfo *Nan::ObjectWrap.Unwrap(= ;
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1585,12 +1592,13 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1652,12 +1660,13 @@ namespace NodeFuse {
         Local<Integer> size = Nan::New<Integer>((int)size_);
         Local<Integer> offset = Nan::New<Integer>((int) off);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1717,12 +1726,13 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//;
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//;
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -1780,12 +1790,13 @@ namespace NodeFuse {
         Local<Number> inode = Nan::New<Number>(ino);
         bool datasync = datasync_ == 0 ? false : true;
 
-        FileInfo* info = new FileInfo();
-        info->fi = fi;
+        // FileInfo* info = new FileInfo();
+        // info->fi = fi;
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
         // memcpy( (void*) info->fi , &fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -2215,11 +2226,12 @@ namespace NodeFuse {
         Local<String> name_ = Nan::New<String>(name).ToLocalChecked();
         Local<Integer> mode_ = Nan::New<Integer>(mode);
 
-        FileInfo* info = new FileInfo();
+        // FileInfo* info = new FileInfo();
         // info->fi = (struct fuse_file_info*) malloc(sizeof(struct fuse_file_info) );
+        // info->fi = fi;
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
         info->fi = fi;
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
 
@@ -2242,7 +2254,7 @@ namespace NodeFuse {
 
     void FileSystem::GetLock(fuse_req_t req,
                              fuse_ino_t ino,
-                             struct fuse_file_info* fi,
+                             struct fuse_file_info fi,
                              struct flock* lock) {
         Nan::HandleScope scope;;
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
@@ -2254,11 +2266,12 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Number> inode = Nan::New<Number>(ino);
 
-        FileInfo* info = new FileInfo();
+        // FileInfo* info = new FileInfo();
         // info->fi = fi;
-        memcpy(&(info->fi), fi, sizeof(struct fuse_file_info));
-        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
+        // memcpy(&(info->fi), fi, sizeof(struct fuse_file_info));
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(info->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
 
         Local<Object> lockObj = FlockToObject(lock)->ToObject();
 
@@ -2280,7 +2293,7 @@ namespace NodeFuse {
 
     void FileSystem::SetLock(fuse_req_t req,
                              fuse_ino_t ino,
-                             struct fuse_file_info* fi,
+                             struct fuse_file_info fi,
                              struct flock* lock,
                              int sleep_) {
         Nan::HandleScope scope;;
@@ -2294,13 +2307,14 @@ namespace NodeFuse {
         Local<Number> inode = Nan::New<Number>(ino);
         Local<Integer> sleep = Nan::New<Integer>(sleep_);
 
-        FileInfo* info = new FileInfo();
+        // FileInfo* info = new FileInfo();
         // info->fi = fi;
-        memcpy(&(info->fi), fi, sizeof(struct fuse_file_info));
-        Local<Function> constructor = Nan::New<Function>(FileInfo::constructor);
-        Local<Object> infoObj = Nan::NewInstance(constructor).ToLocalChecked();//->GetFunction()->NewInstance();
-        info->Wrap(infoObj);
-
+        // memcpy(&(info->fi), fi, sizeof(struct fuse_file_info));
+        // Local<Function> constructor = Nan::New<Function>(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked();;
+        Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(constructor).ToLocalChecked();//->GetFunction()->FileInfo *Nan::ObjectWrap.Unwrap(= ;
+        FileInfo *info = Nan::ObjectWrap::Unwrap<FileInfo>(infoObj);
+        info->fi = fi;
+        
         Local<Object> lockObj = FlockToObject(lock)->ToObject();
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -12,6 +12,50 @@
  
 namespace NodeFuse {
     Persistent<Function> FileSystem::constructor;
+    static Nan::Persistent<String> init_sym;
+    static Nan::Persistent<String> destroy_sym;
+    static Nan::Persistent<String> lookup_sym;
+    static Nan::Persistent<String> forget_sym;
+    static Nan::Persistent<String> getattr_sym;
+    static Nan::Persistent<String> setattr_sym;
+    static Nan::Persistent<String> readlink_sym;
+    static Nan::Persistent<String> mknod_sym;
+    static Nan::Persistent<String> mkdir_sym;
+    static Nan::Persistent<String> unlink_sym;
+    static Nan::Persistent<String> rmdir_sym;
+    static Nan::Persistent<String> symlink_sym;
+    static Nan::Persistent<String> rename_sym;
+    static Nan::Persistent<String> link_sym;
+    static Nan::Persistent<String> open_sym;
+    static Nan::Persistent<String> read_sym;
+    static Nan::Persistent<String> write_sym;
+    static Nan::Persistent<String> flush_sym;
+    static Nan::Persistent<String> release_sym;
+    static Nan::Persistent<String> fsync_sym;
+    static Nan::Persistent<String> opendir_sym;
+    static Nan::Persistent<String> readdir_sym;
+    static Nan::Persistent<String> releasedir_sym;
+    static Nan::Persistent<String> fsyncdir_sym;
+    static Nan::Persistent<String> statfs_sym;
+    static Nan::Persistent<String> setxattr_sym;
+    static Nan::Persistent<String> getxattr_sym;
+    static Nan::Persistent<String> listxattr_sym;
+    static Nan::Persistent<String> removexattr_sym;
+    static Nan::Persistent<String> access_sym;
+    static Nan::Persistent<String> create_sym;
+    static Nan::Persistent<String> getlk_sym;
+    static Nan::Persistent<String> setlk_sym;
+    static Nan::Persistent<String> bmap_sym;
+    static Nan::Persistent<String> ioctl_sym;
+    static Nan::Persistent<String> poll_sym;
+    static Nan::Persistent<String> conn_info_proto_major_sym;
+    static Nan::Persistent<String> conn_info_proto_minor_sym;
+    static Nan::Persistent<String> conn_info_async_read_sym;
+    static Nan::Persistent<String> conn_info_max_write_sym;
+    static Nan::Persistent<String> conn_info_max_readahead_sym;
+    static Nan::Persistent<String> conn_info_capable_sym;
+    static Nan::Persistent<String> conn_info_want_sym;
+    static Nan::Persistent<String> multiforget_sym;
 
     // struct vrt_fuse_cmd_value
     // {
@@ -310,49 +354,51 @@ namespace NodeFuse {
         // fuse_ops.ioctl      = FileSystem::IOCtl;
         // fuse_ops.poll       = FileSystem::Poll;
 
-        // init_sym Nan::New("init"));
-        // NanAssignPersistent(destroy_sym,     Nan::New("destroy"));
-        // NanAssignPersistent(lookup_sym,      Nan::New("lookup"));
-        // NanAssignPersistent(forget_sym,      Nan::New("forget"));
-        // NanAssignPersistent(getattr_sym,     Nan::New("getattr"));
-        // NanAssignPersistent(setattr_sym,     Nan::New("setattr"));
-        // NanAssignPersistent(readlink_sym,    Nan::New("readlink"));
-        // NanAssignPersistent(mknod_sym,       Nan::New("mknod"));
-        // NanAssignPersistent(mkdir_sym,       Nan::New("mkdir"));
-        // NanAssignPersistent(unlink_sym,      Nan::New("unlink"));
-        // NanAssignPersistent(rmdir_sym,       Nan::New("rmdir"));
-        // NanAssignPersistent(symlink_sym,     Nan::New("symlink"));
-        // NanAssignPersistent(rename_sym,      Nan::New("rename"));
-        // NanAssignPersistent(link_sym,        Nan::New("link"));
-        // NanAssignPersistent(open_sym,        Nan::New("open"));
-        // NanAssignPersistent(read_sym,        Nan::New("read"));
-        // NanAssignPersistent(write_sym,       Nan::New("write"));
-        // NanAssignPersistent(flush_sym,       Nan::New("flush"));
-        // NanAssignPersistent(release_sym,     Nan::New("release"));
-        // NanAssignPersistent(fsync_sym,       Nan::New("fsync"));
-        // NanAssignPersistent(opendir_sym,     Nan::New("opendir"));
-        // NanAssignPersistent(readdir_sym,     Nan::New("readdir"));
-        // NanAssignPersistent(releasedir_sym,  Nan::New("releasedir"));
-        // NanAssignPersistent(fsyncdir_sym,    Nan::New("fsyncdir"));
-        // NanAssignPersistent(statfs_sym,      Nan::New("statfs"));
-        // NanAssignPersistent(setxattr_sym,    Nan::New("setxattr"));
-        // NanAssignPersistent(getxattr_sym,    Nan::New("getxattr"));
-        // NanAssignPersistent(listxattr_sym,   Nan::New("listxattr"));
-        // NanAssignPersistent(removexattr_sym, Nan::New("removexattr"));
-        // NanAssignPersistent(access_sym,      Nan::New("access"));
-        // NanAssignPersistent(create_sym,      Nan::New("create"));
-        // NanAssignPersistent(getlk_sym,       Nan::New("getlk"));
-        // NanAssignPersistent(setlk_sym,       Nan::New("setlk"));
-        // NanAssignPersistent(bmap_sym,        Nan::New("bmap"));
-        // NanAssignPersistent(ioctl_sym,       Nan::New("ioctl"));
-        // NanAssignPersistent(poll_sym,        Nan::New("poll"));
-        // NanAssignPersistent(conn_info_proto_major_sym,     Nan::New("proto_major"));
-        // NanAssignPersistent(conn_info_proto_minor_sym,     Nan::New("proto_minor"));
-        // NanAssignPersistent(conn_info_async_read_sym,      Nan::New("async_read"));
-        // NanAssignPersistent(conn_info_max_write_sym,       Nan::New("max_write"));
-        // NanAssignPersistent(conn_info_max_readahead_sym,   Nan::New("max_readahead"));
-        // NanAssignPersistent(conn_info_capable_sym,         Nan::New("capable"));
-        // NanAssignPersistent(conn_info_want_sym,            Nan::New("want"));
+        init_sym.Reset( Nan::New<String>("init").ToLocalChecked());
+        destroy_sym.Reset( Nan::New<String>("destroy").ToLocalChecked());
+        lookup_sym.Reset( Nan::New<String>("lookup").ToLocalChecked());
+        forget_sym.Reset( Nan::New<String>("forget").ToLocalChecked());
+        getattr_sym.Reset( Nan::New<String>("getattr").ToLocalChecked());
+        setattr_sym.Reset( Nan::New<String>("setattr").ToLocalChecked());
+        readlink_sym.Reset( Nan::New<String>("readlink").ToLocalChecked());
+        mknod_sym.Reset( Nan::New<String>("mknod").ToLocalChecked());
+        mkdir_sym.Reset( Nan::New<String>("mkdir").ToLocalChecked());
+        unlink_sym.Reset( Nan::New<String>("unlink").ToLocalChecked());
+        rmdir_sym.Reset( Nan::New<String>("rmdir").ToLocalChecked());
+        symlink_sym.Reset( Nan::New<String>("symlink").ToLocalChecked());
+        rename_sym.Reset( Nan::New<String>("rename").ToLocalChecked());
+        link_sym.Reset( Nan::New<String>("link").ToLocalChecked());
+        open_sym.Reset( Nan::New<String>("open").ToLocalChecked());
+        read_sym.Reset( Nan::New<String>("read").ToLocalChecked());
+        write_sym.Reset( Nan::New<String>("write").ToLocalChecked());
+        flush_sym.Reset( Nan::New<String>("flush").ToLocalChecked());
+        release_sym.Reset( Nan::New<String>("release").ToLocalChecked());
+        fsync_sym.Reset( Nan::New<String>("fsync").ToLocalChecked());
+        opendir_sym.Reset( Nan::New<String>("opendir").ToLocalChecked());
+        readdir_sym.Reset( Nan::New<String>("readdir").ToLocalChecked());
+        releasedir_sym.Reset( Nan::New<String>("releasedir").ToLocalChecked());
+        fsyncdir_sym.Reset( Nan::New<String>("fsyncdir").ToLocalChecked());
+        statfs_sym.Reset( Nan::New<String>("statfs").ToLocalChecked());
+        setxattr_sym.Reset( Nan::New<String>("setxattr").ToLocalChecked());
+        getxattr_sym.Reset( Nan::New<String>("getxattr").ToLocalChecked());
+        listxattr_sym.Reset( Nan::New<String>("listxattr").ToLocalChecked());
+        removexattr_sym.Reset( Nan::New<String>("removexattr").ToLocalChecked());
+        access_sym.Reset( Nan::New<String>("access").ToLocalChecked());
+        create_sym.Reset( Nan::New<String>("create").ToLocalChecked());
+        getlk_sym.Reset( Nan::New<String>("getlk").ToLocalChecked());
+        setlk_sym.Reset( Nan::New<String>("setlk").ToLocalChecked());
+        bmap_sym.Reset( Nan::New<String>("bmap").ToLocalChecked());
+        ioctl_sym.Reset( Nan::New<String>("ioctl").ToLocalChecked());
+        poll_sym.Reset( Nan::New<String>("poll").ToLocalChecked());
+        conn_info_proto_major_sym.Reset( Nan::New<String>("proto_major").ToLocalChecked());
+        conn_info_proto_minor_sym.Reset( Nan::New<String>("proto_minor").ToLocalChecked());
+        conn_info_async_read_sym.Reset( Nan::New<String>("async_read").ToLocalChecked());
+        conn_info_max_write_sym.Reset( Nan::New<String>("max_write").ToLocalChecked());
+        conn_info_max_readahead_sym.Reset( Nan::New<String>("max_readahead").ToLocalChecked());
+        conn_info_capable_sym.Reset( Nan::New<String>("capable").ToLocalChecked());
+        conn_info_want_sym.Reset( Nan::New<String>("want").ToLocalChecked());
+        multiforget_sym.Reset( Nan::New<String>("multiforget").ToLocalChecked());
+        
     }
 
     void FileSystem::Init(void* userdata,
@@ -384,11 +430,11 @@ namespace NodeFuse {
         //These properties will be read-only for now.
         //TODO set accessors for read/write properties
         Local<Object> info = Nan::New<Object>();
-        info->Set(Nan::New<String>("conn_info_proto_major").ToLocalChecked(), Nan::New<Integer>(conn.proto_major));
-        info->Set(Nan::New<String>("conn_info_proto_minor").ToLocalChecked(), Nan::New<Integer>(conn.proto_minor));
-        info->Set(Nan::New<String>("conn_info_async_read").ToLocalChecked(), Nan::New<Integer>(conn.async_read));
-        info->Set(Nan::New<String>("conn_info_max_write").ToLocalChecked(), Nan::New<Number>(conn.max_write));
-        info->Set(Nan::New<String>("conn_info_max_readahead").ToLocalChecked(), Nan::New<Number>(conn.max_readahead));
+        info->Set(Nan::New(conn_info_proto_major_sym), Nan::New<Integer>(conn.proto_major));
+        info->Set(Nan::New(conn_info_proto_minor_sym), Nan::New<Integer>(conn.proto_minor));
+        info->Set(Nan::New(conn_info_async_read_sym), Nan::New<Integer>(conn.async_read));
+        info->Set(Nan::New(conn_info_max_write_sym), Nan::New<Number>(conn.max_write));
+        info->Set(Nan::New(conn_info_max_readahead_sym), Nan::New<Number>(conn.max_readahead));
         //TODO macro to enable certain properties given the fuse version
         //info->Set(conn_info_capable_sym, Nan::New<Integer>(conn.capable));
         //info->Set(conn_info_want_sym, Nan::New<Integer>(conn.want));
@@ -423,7 +469,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
         Fuse* fuse = static_cast<Fuse *>(userdata);
         Local<Object> fsobj = Nan::New(fuse->fsobj);
-        Local<Value> vdestroy = fsobj->Get(Nan::New<String>("destroy").ToLocalChecked());
+        Local<Value> vdestroy = fsobj->Get(Nan::New(destroy_sym));
         Local<Function> destroy = Local<Function>::Cast(vdestroy);
 
         Nan::TryCatch try_catch;
@@ -462,7 +508,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
-        Local<Value> vlookup = fsobj->Get(Nan::New<String>("lookup").ToLocalChecked());
+        Local<Value> vlookup = fsobj->Get(Nan::New(lookup_sym));
         Local<Function> lookup = Local<Function>::Cast(vlookup);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -513,7 +559,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
-        Local<Value> vforget = fsobj->Get(Nan::New<String>("multiforget").ToLocalChecked());
+        Local<Value> vforget = fsobj->Get(Nan::New(multiforget_sym));
         Local<Function> forget = Local<Function>::Cast(vforget);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -573,7 +619,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
-        Local<Value> vforget = fsobj->Get(Nan::New<String>("forget").ToLocalChecked());
+        Local<Value> vforget = fsobj->Get(Nan::New(forget_sym) );
         Local<Function> forget = Local<Function>::Cast(vforget);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -630,7 +676,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vgetattr = fsobj->Get(Nan::New<String>("getattr").ToLocalChecked());
+        Local<Value> vgetattr = fsobj->Get(Nan::New(getattr_sym));
         Local<Function> getattr = Local<Function>::Cast(vgetattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -692,7 +738,7 @@ namespace NodeFuse {
         Fuse *fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vsetattr = fsobj->Get(Nan::New<String>("setattr").ToLocalChecked());
+        Local<Value> vsetattr = fsobj->Get(Nan::New(setattr_sym));
         Local<Function> setattr = Local<Function>::Cast(vsetattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -741,7 +787,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vreadlink = fsobj->Get(Nan::New<String>("readlink").ToLocalChecked());
+        Local<Value> vreadlink = fsobj->Get(Nan::New(readlink_sym));
         Local<Function> readlink = Local<Function>::Cast(vreadlink);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -799,7 +845,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vmknod = fsobj->Get(Nan::New<String>("mknod").ToLocalChecked());
+        Local<Value> vmknod = fsobj->Get(Nan::New(mknod_sym));
         Local<Function> mknod = Local<Function>::Cast(vmknod);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -860,7 +906,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vmkdir = fsobj->Get(Nan::New<String>("mkdir").ToLocalChecked());
+        Local<Value> vmkdir = fsobj->Get(Nan::New(mkdir_sym));
         Local<Function> mkdir = Local<Function>::Cast(vmkdir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -916,7 +962,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vunlink = fsobj->Get(Nan::New<String>("unlink").ToLocalChecked());
+        Local<Value> vunlink = fsobj->Get(Nan::New(unlink_sym));
         Local<Function> unlink = Local<Function>::Cast(vunlink);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -969,7 +1015,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vrmdir = fsobj->Get(Nan::New<String>("rmdir").ToLocalChecked());
+        Local<Value> vrmdir = fsobj->Get(Nan::New(rmdir_sym));
         Local<Function> rmdir = Local<Function>::Cast(vrmdir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1023,7 +1069,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vsymlink = fsobj->Get(Nan::New<String>("symlink").ToLocalChecked());
+        Local<Value> vsymlink = fsobj->Get(Nan::New(symlink_sym));
         Local<Function> symlink = Local<Function>::Cast(vsymlink);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1081,7 +1127,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vrename = fsobj->Get(Nan::New<String>("rename").ToLocalChecked());
+        Local<Value> vrename = fsobj->Get(Nan::New(rename_sym));
         Local<Function> rename = Local<Function>::Cast(vrename);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1138,7 +1184,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vlink = fsobj->Get(Nan::New<String>("link").ToLocalChecked());
+        Local<Value> vlink = fsobj->Get(Nan::New(link_sym));
         Local<Function> link = Local<Function>::Cast(vlink);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1193,7 +1239,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vopen = fsobj->Get(Nan::New<String>("open").ToLocalChecked());
+        Local<Value> vopen = fsobj->Get(Nan::New(open_sym));
         Local<Function> open = Local<Function>::Cast(vopen);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1262,7 +1308,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vread = fsobj->Get(Nan::New<String>("read").ToLocalChecked());
+        Local<Value> vread = fsobj->Get(Nan::New(read_sym));
         Local<Function> read = Local<Function>::Cast(vread);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1339,7 +1385,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vwrite = fsobj->Get(Nan::New<String>("write").ToLocalChecked());
+        Local<Value> vwrite = fsobj->Get(Nan::New(write_sym));
         Local<Function> write = Local<Function>::Cast(vwrite);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1406,7 +1452,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vflush = fsobj->Get(Nan::New<String>("flush").ToLocalChecked());
+        Local<Value> vflush = fsobj->Get(Nan::New(flush_sym));
         Local<Function> flush = Local<Function>::Cast(vflush);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1468,7 +1514,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vrelease = fsobj->Get(Nan::New<String>("release").ToLocalChecked());
+        Local<Value> vrelease = fsobj->Get(Nan::New(release_sym));
         Local<Function> release = Local<Function>::Cast(vrelease);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1531,7 +1577,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vfsync = fsobj->Get(Nan::New<String>("fsync").ToLocalChecked());
+        Local<Value> vfsync = fsobj->Get(Nan::New(fsync_sym));
         Local<Function> fsync = Local<Function>::Cast(vfsync);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1592,7 +1638,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vopendir = fsobj->Get(Nan::New<String>("opendir").ToLocalChecked());
+        Local<Value> vopendir = fsobj->Get(Nan::New(opendir_sym));
         Local<Function> opendir = Local<Function>::Cast(vopendir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1658,7 +1704,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vreaddir = fsobj->Get(Nan::New<String>("readdir").ToLocalChecked());
+        Local<Value> vreaddir = fsobj->Get(Nan::New(readdir_sym));
         Local<Function> readdir = Local<Function>::Cast(vreaddir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1726,7 +1772,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vreleasedir = fsobj->Get(Nan::New<String>("releasedir").ToLocalChecked());
+        Local<Value> vreleasedir = fsobj->Get(Nan::New(releasedir_sym));
         Local<Function> releasedir = Local<Function>::Cast(vreleasedir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1789,7 +1835,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vfsyncdir = fsobj->Get(Nan::New<String>("fsyncdir").ToLocalChecked());
+        Local<Value> vfsyncdir = fsobj->Get(Nan::New(fsyncdir_sym));
         Local<Function> fsyncdir = Local<Function>::Cast(vfsyncdir);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1843,7 +1889,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vstatfs = fsobj->Get(Nan::New<String>("statfs").ToLocalChecked());
+        Local<Value> vstatfs = fsobj->Get(Nan::New(statfs_sym));
         Local<Function> statfs = Local<Function>::Cast(vstatfs);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -1915,7 +1961,7 @@ namespace NodeFuse {
         Fuse *fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vsetxattr = fsobj->Get(Nan::New<String>("setxattr").ToLocalChecked());
+        Local<Value> vsetxattr = fsobj->Get(Nan::New(setxattr_sym));
         Local<Function> setxattr = Local<Function>::Cast(vsetxattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2003,7 +2049,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vgetxattr = fsobj->Get(Nan::New<String>("getxattr").ToLocalChecked());
+        Local<Value> vgetxattr = fsobj->Get(Nan::New(getxattr_sym));
         Local<Function> getxattr = Local<Function>::Cast(vgetxattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2069,7 +2115,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vlistxattr = fsobj->Get(Nan::New<String>("listxattr").ToLocalChecked());
+        Local<Value> vlistxattr = fsobj->Get(Nan::New(listxattr_sym));
         Local<Function> listxattr = Local<Function>::Cast(vlistxattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2116,7 +2162,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vremovexattr = fsobj->Get(Nan::New<String>("removexattr").ToLocalChecked());
+        Local<Value> vremovexattr = fsobj->Get(Nan::New(removexattr_sym));
         Local<Function> removexattr = Local<Function>::Cast(vremovexattr);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2167,7 +2213,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vaccess = fsobj->Get(Nan::New<String>("access").ToLocalChecked());
+        Local<Value> vaccess = fsobj->Get(Nan::New(access_sym));
         Local<Function> access = Local<Function>::Cast(vaccess);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2226,7 +2272,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vcreate = fsobj->Get(Nan::New<String>("create").ToLocalChecked());
+        Local<Value> vcreate = fsobj->Get(Nan::New(create_sym));
         Local<Function> create = Local<Function>::Cast(vcreate);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2268,7 +2314,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vgetlk = fsobj->Get(Nan::New<String>("getlk").ToLocalChecked());
+        Local<Value> vgetlk = fsobj->Get(Nan::New(getlk_sym));
         Local<Function> getlk = Local<Function>::Cast(vgetlk);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
@@ -2308,7 +2354,7 @@ namespace NodeFuse {
         Fuse* fuse = static_cast<Fuse *>(fuse_req_userdata(req));
         Local<Object> fsobj = Nan::New(fuse->fsobj);
 
-        Local<Value> vsetlk = fsobj->Get(Nan::New<String>("setlk").ToLocalChecked());
+        Local<Value> vsetlk = fsobj->Get(Nan::New(setlk_sym));
         Local<Function> setlk = Local<Function>::Cast(vsetlk);
 
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -524,16 +524,16 @@ namespace NodeFuse {
         Local<Object> context = RequestContextToObject(fuse_req_ctx(req))->ToObject();
         Local<Array> data = Nan::New<Array>(count);
 
-        // for( uint i = 0; i < count; i++){
-            ForgetData *forget_data = new ForgetData();
-            // forget_data->fd = &( forget_all[i] );
-            Local<Object> infoObj = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(forget_data->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-            FileInfo *data = Nan::ObjectWrap.Unwrap(i, infoObj);
-            info->fi = fi;
+        for( uint i = 0; i < count; i++){
+        // ForgetData *forget_data = new ForgetData();
+        // forget_data->fd = &( forget_all[i] );
+            Local<Object> forgetObject = Nan::NewInstance(Nan::New<Function>(FileInfo::constructor)).ToLocalChecked(); //Nan::NewInstance(Nan::New<Function>(forget_data->constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
+            ForgetData *forget_data = Nan::ObjectWrap::Unwrap<ForgetData>(forgetObject);
+            forget_data->fd = &( forget_all[i] );
+            data->Set(i, forgetObject);
         }
 
         Local<Object> replyObj = Nan::NewInstance( Nan::New<Function>(Reply::constructor)).ToLocalChecked();//->GetFunction()->NewInstance();
-
         Reply *reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
         reply->request = req;
         Local<Value> argv[3] = {context, data, replyObj};

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -215,11 +215,11 @@ namespace NodeFuse {
                                struct fuse_file_info* fi);
             static void GetLock(fuse_req_t req,
                               fuse_ino_t ino,
-                              struct fuse_file_info* fi,
+                              struct fuse_file_info fi,
                               struct flock* lock);
             static void SetLock(fuse_req_t req,
                               fuse_ino_t ino,
-                              struct fuse_file_info* fi,
+                              struct fuse_file_info fi,
                               struct flock* lock,
                               int sleep);
             static void BMap(fuse_req_t req,

--- a/src/forget_data.cc
+++ b/src/forget_data.cc
@@ -31,19 +31,19 @@ namespace NodeFuse {
 		constructor.Reset(tpl->GetFunction());
 
 	}
-	ForgetData::ForgetData() : ObjectWrap() {}
+	ForgetData::ForgetData() : Nan::ObjectWrap() {}
 	ForgetData::~ForgetData() {}
 	void ForgetData::GetIno(v8::Local<v8::String> property,
                 const Nan::PropertyCallbackInfo<v8::Value>& info) 
 	{
-		ForgetData *forget_data = ObjectWrap::Unwrap<ForgetData>(info.This());
+		ForgetData *forget_data = Nan::ObjectWrap::Unwrap<ForgetData>(info.This());
 		info.GetReturnValue().Set( Nan::New<Integer>(static_cast<uint32_t>(forget_data->fd->ino)));
 	}
 
 	void ForgetData::GetNLookup(v8::Local<v8::String> property,
                 const Nan::PropertyCallbackInfo<v8::Value>& info) 
 	{
-		ForgetData *forget_data = ObjectWrap::Unwrap<ForgetData>(info.This());
+		ForgetData *forget_data = Nan::ObjectWrap::Unwrap<ForgetData>(info.This());
 		info.GetReturnValue().Set( Nan::New<Integer>( static_cast<uint32_t>(forget_data->fd->nlookup)) );
 	}
 

--- a/src/forget_data.h
+++ b/src/forget_data.h
@@ -10,7 +10,7 @@
 #if FUSE_VERSION > 28 
 
 namespace NodeFuse {
-    class ForgetData : public ObjectWrap {
+    class ForgetData : public Nan::ObjectWrap {
         friend class FileSystem;
         public:
             static void Initialize(Handle<Object> target);

--- a/src/reply.cc
+++ b/src/reply.cc
@@ -44,7 +44,7 @@ namespace NodeFuse {
         constructor.Reset(tpl->GetFunction());
     }
 
-    Reply::Reply() : ObjectWrap() {
+    Reply::Reply() : Nan::ObjectWrap() {
         dentry_acc_size = 0;
         dentry_cur_length = 0;
         dentry_size = 0;
@@ -63,7 +63,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -97,7 +97,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -140,7 +140,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -153,7 +153,7 @@ namespace NodeFuse {
             Nan::ThrowTypeError( "You must specify a string as first argument");
         }
 
-        String::Utf8Value link(arg->ToString());
+        String::Utf8Value link(arg);
 
         int ret = -1;
         ret = fuse_reply_readlink(reply->request, (const char*) *link);
@@ -169,7 +169,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -195,7 +195,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -207,7 +207,7 @@ namespace NodeFuse {
             Nan::ThrowTypeError( "You must specify a FileInfo object as first argument");
         }
 
-        FileInfo* fileInfo = ObjectWrap::Unwrap<FileInfo>(fiobj);
+        FileInfo* fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(fiobj);
 
         int ret = -1;
         ret = fuse_reply_open(reply->request, &(fileInfo->fi));
@@ -222,7 +222,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -274,7 +274,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -300,7 +300,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int ret = -1;
         struct statvfs buf;
@@ -333,7 +333,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -359,7 +359,7 @@ namespace NodeFuse {
             Nan::ThrowTypeError( "You must specify a FileInfo object as second argument");
         }
 
-        FileInfo* fileInfo = ObjectWrap::Unwrap<FileInfo>(fiobj);
+        FileInfo* fileInfo = Nan::ObjectWrap::Unwrap<FileInfo>(fiobj);
 
         ret = fuse_reply_create(reply->request, &entry, &(fileInfo->fi));
         reply->b_hasReplied = true;
@@ -373,7 +373,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -398,7 +398,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -428,9 +428,9 @@ namespace NodeFuse {
     }
 
     void Reply::None(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-        Nan::EscapableHandleScope scope;
+        Nan::HandleScope scope;
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);       
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);       
         fuse_reply_none(reply->request); 
         reply->b_hasReplied = true;
     }
@@ -440,7 +440,7 @@ namespace NodeFuse {
         Nan::HandleScope scope;;
 
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
         if (argslen == 0) {
@@ -462,9 +462,9 @@ namespace NodeFuse {
     }
 
     void Reply::AddDirEntry(const Nan::FunctionCallbackInfo<v8::Value>& args) {
-        Nan::EscapableHandleScope scope;
+        Nan::HandleScope scope;
         Local<Object> replyObj = args.This();
-        Reply* reply = ObjectWrap::Unwrap<Reply>(replyObj);
+        Reply* reply = Nan::ObjectWrap::Unwrap<Reply>(replyObj);
 
         int argslen = args.Length();
 
@@ -488,7 +488,7 @@ namespace NodeFuse {
             Nan::ThrowTypeError("You must specify a offset number as fourth argument");
         }
 
-        String::Utf8Value name(args[0]->ToString());
+        String::Utf8Value name(args[0]);
         size_t requestedSize = args[1]->IntegerValue();
         off_t offset = args[3]->IntegerValue();
         reply-> dentry_offset = offset;
@@ -524,7 +524,7 @@ namespace NodeFuse {
     }
     
     NAN_GETTER(Reply::hasReplied){
-        Reply *reply = ObjectWrap::Unwrap<Reply>(info.This());
+        Reply *reply = Nan::ObjectWrap::Unwrap<Reply>(info.This());
         info.GetReturnValue().Set(reply->b_hasReplied ? Nan::True() : Nan::False());
     }
 

--- a/src/reply.h
+++ b/src/reply.h
@@ -7,7 +7,7 @@
 #include "node_fuse.h"
 
 namespace NodeFuse {
-    class Reply : public ObjectWrap {
+    class Reply : public Nan::ObjectWrap {
         friend class FileSystem;
 
         public:


### PR DESCRIPTION
Added persistent objects for filesystem class that was missed from pull request #30.

When creating Reply and FileInfo objects to send to the filesystem, create the v8 object and unwrap it instead of creating the c++ and wrapping it. This fixes some weird behaviours with the reply and fileinfo objects. 
